### PR TITLE
 Add 'required' option to ChatCompletionToolChoiceOption type

### DIFF
--- a/openapi/azure/openai.chat/2023-12-01-preview/openapi.yml
+++ b/openapi/azure/openai.chat/2023-12-01-preview/openapi.yml
@@ -1164,13 +1164,14 @@ components:
         - assistant
       description: The role of the author of the response message.
     chatCompletionToolChoiceOption:
-      description: 'Controls which (if any) function is called by the model. `none` means the model will not call a function and instead generates a message. `auto` means the model can pick between generating a message or calling a function. Specifying a particular function via `{"type": "function", "function": {"name": "my_function"}}` forces the model to call that function.'
+      description: 'Controls which (if any) function is called by the model. `none` means the model will not call a function and instead generates a message. `auto` means the model can pick between generating a message or calling a function. `required` means the model will always call one or more functions before generating a message. Specifying a particular function via `{"type": "function", "function": {"name": "my_function"}}` forces the model to call that function.'
       oneOf:
         - type: string
-          description: '`none` means the model will not call a function and instead generates a message. `auto` means the model can pick between generating a message or calling a function.'
+          description: '`none` means the model will not call a function and instead generates a message. `auto` means the model can pick between generating a message or calling a function. `required` means the model will always call one or more functions before generating a message.'
           enum:
             - none
             - auto
+            - required
         - $ref: '#/components/schemas/chatCompletionNamedToolChoice'
     chatCompletionNamedToolChoice:
       type: object


### PR DESCRIPTION
## Purpose

Added a new option `\"required\"` to the `ChatCompletionToolChoiceOption` type in the `types.bal` file. This change enhances the flexibility of tool choice options.

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/7909
